### PR TITLE
UI: removed auto-connection on initial server selection from the connection view.

### DIFF
--- a/ui/src/UI/Views/ConnectionView.xaml.cs
+++ b/ui/src/UI/Views/ConnectionView.xaml.cs
@@ -50,10 +50,6 @@ namespace FirefoxPrivateNetwork.UI
                 {
                     WireGuard.Connector.Connect(switchServer: true, previousServerCity: previousSelectedItem.Name, switchServerCity: selectedServer.Name);
                 }
-                else if (Manager.MainWindowViewModel.Status == Models.ConnectionState.Unprotected)
-                {
-                    WireGuard.Connector.Connect();
-                }
 
                 NavigateMain(sender, e);
             }


### PR DESCRIPTION
Previously, when the user is unprotected, the client automatically initiates a connection when a server is selected, which isn't intuitive.  With this change, in the same scenario, selecting a server will return them to the main view, where the user must click the connection toggle to connect to the server.