### PR TITLE
ui: Modify skip button behaviour on onboarding views.

### DIFF
--- a/ui/src/UI/Views/Onboarding/OnboardingView1.xaml
+++ b/ui/src/UI/Views/Onboarding/OnboardingView1.xaml
@@ -27,7 +27,7 @@
                 <DockPanel VerticalAlignment="Center">
                     <Button Style="{StaticResource 'Icon'}" Width="40" Height="40" Margin="8,0" VerticalAlignment="Center" local:ButtonExtensions.IconUri="{StaticResource 'close-small'}" Click="ExitOnboarding"/>
                     <TextBlock Style="{StaticResource 'Header 10'}" Foreground="{StaticResource 'Blue/Blue 50'}" TextAlignment="Right" TextDecorations="{x:Null}" Margin="16,17,16,16">
-                        <Hyperlink Click="Skip_Click" TextDecorations="{x:Null}">
+                        <Hyperlink Click="SkipOnboarding" TextDecorations="{x:Null}">
                             <TextBlock Text="{Binding Path=[nux-skip]}"/>
                         </Hyperlink>
                     </TextBlock>

--- a/ui/src/UI/Views/Onboarding/OnboardingView1.xaml.cs
+++ b/ui/src/UI/Views/Onboarding/OnboardingView1.xaml.cs
@@ -45,10 +45,10 @@ namespace FirefoxPrivateNetwork.UI
             mainWindow.NavigateToView(new LandingView(), MainWindow.SlideDirection.Down);
         }
 
-        private void Skip_Click(object sender, RoutedEventArgs e)
+        private void SkipOnboarding(object sender, RoutedEventArgs e)
         {
-            var fxaLoginThread = new FxA.Login();
-            fxaLoginThread.StartLogin();
+            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+            mainWindow.NavigateToView(new OnboardingView4(), MainWindow.SlideDirection.Left);
         }
     }
 }

--- a/ui/src/UI/Views/Onboarding/OnboardingView2.xaml
+++ b/ui/src/UI/Views/Onboarding/OnboardingView2.xaml
@@ -27,7 +27,7 @@
                 <DockPanel VerticalAlignment="Center">
                     <Button Style="{StaticResource 'Icon'}" Width="40" Height="40" Margin="8,0" VerticalAlignment="Center" local:ButtonExtensions.IconUri="{StaticResource 'close-small'}" Click="ExitOnboarding"/>
                     <TextBlock Style="{StaticResource 'Header 10'}" Foreground="{StaticResource 'Blue/Blue 50'}" TextAlignment="Right" TextDecorations="{x:Null}" Margin="16,17,16,16">
-                        <Hyperlink Click="Skip_Click" TextDecorations="{x:Null}">
+                        <Hyperlink Click="SkipOnboarding" TextDecorations="{x:Null}">
                             <TextBlock Text="{Binding Path=[nux-skip]}"/>
                         </Hyperlink>
                     </TextBlock>

--- a/ui/src/UI/Views/Onboarding/OnboardingView2.xaml.cs
+++ b/ui/src/UI/Views/Onboarding/OnboardingView2.xaml.cs
@@ -45,10 +45,10 @@ namespace FirefoxPrivateNetwork.UI
             mainWindow.NavigateToView(new LandingView(), MainWindow.SlideDirection.Down);
         }
 
-        private void Skip_Click(object sender, RoutedEventArgs e)
+        private void SkipOnboarding(object sender, RoutedEventArgs e)
         {
-            var fxaLoginThread = new FxA.Login();
-            fxaLoginThread.StartLogin();
+            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+            mainWindow.NavigateToView(new OnboardingView4(), MainWindow.SlideDirection.Left);
         }
     }
 }

--- a/ui/src/UI/Views/Onboarding/OnboardingView3.xaml
+++ b/ui/src/UI/Views/Onboarding/OnboardingView3.xaml
@@ -27,7 +27,7 @@
                 <DockPanel VerticalAlignment="Center">
                     <Button Style="{StaticResource 'Icon'}" Width="40" Height="40" Margin="8,0" VerticalAlignment="Center" local:ButtonExtensions.IconUri="{StaticResource 'close-small'}" Click="ExitOnboarding"/>
                     <TextBlock Style="{StaticResource 'Header 10'}" Foreground="{StaticResource 'Blue/Blue 50'}" TextAlignment="Right" TextDecorations="{x:Null}" Margin="16,17,16,16">
-                        <Hyperlink Click="Skip_Click" TextDecorations="{x:Null}">
+                        <Hyperlink Click="SkipOnboarding" TextDecorations="{x:Null}">
                             <TextBlock Text="{Binding Path=[nux-skip]}"/>
                         </Hyperlink>
                     </TextBlock>

--- a/ui/src/UI/Views/Onboarding/OnboardingView3.xaml.cs
+++ b/ui/src/UI/Views/Onboarding/OnboardingView3.xaml.cs
@@ -45,10 +45,10 @@ namespace FirefoxPrivateNetwork.UI
             mainWindow.NavigateToView(new LandingView(), MainWindow.SlideDirection.Down);
         }
 
-        private void Skip_Click(object sender, RoutedEventArgs e)
+        private void SkipOnboarding(object sender, RoutedEventArgs e)
         {
-            var fxaLoginThread = new FxA.Login();
-            fxaLoginThread.StartLogin();
+            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+            mainWindow.NavigateToView(new OnboardingView4(), MainWindow.SlideDirection.Left);
         }
     }
 }


### PR DESCRIPTION
When the skip button on one of the onboarding screens is clicked, the client will navigate to the last onboarding screen, where the user will be able to initiate the login flow.